### PR TITLE
net-wireless/sdrangel: fix codec2 dependency

### DIFF
--- a/net-wireless/sdrangel/sdrangel-7.6.0-r1.ebuild
+++ b/net-wireless/sdrangel/sdrangel-7.6.0-r1.ebuild
@@ -33,7 +33,8 @@ RDEPEND="
 	>=dev-qt/qtwebsockets-5.6.0
 	>=dev-qt/qtmultimedia-5.6.0[widgets]
 	dev-qt/qtserialport
-	=media-libs/codec2-1.0.3
+	>=media-libs/codec2-1.0.3
+	!!=media-libs/codec2-1.0.4
 	media-libs/opus
 	net-wireless/dsdcc
 	sci-libs/fftw:3.0

--- a/net-wireless/sdrangel/sdrangel-7.6.1-r1.ebuild
+++ b/net-wireless/sdrangel/sdrangel-7.6.1-r1.ebuild
@@ -33,7 +33,8 @@ RDEPEND="
 	>=dev-qt/qtwebsockets-5.6.0
 	>=dev-qt/qtmultimedia-5.6.0[widgets]
 	dev-qt/qtserialport
-	>=media-libs/codec2-0.9.1
+	>=media-libs/codec2-1.0.3
+	!!=media-libs/codec2-1.0.4
 	media-libs/opus
 	net-wireless/dsdcc
 	sci-libs/fftw:3.0

--- a/net-wireless/sdrangel/sdrangel-7.6.1.ebuild
+++ b/net-wireless/sdrangel/sdrangel-7.6.1.ebuild
@@ -33,7 +33,7 @@ RDEPEND="
 	>=dev-qt/qtwebsockets-5.6.0
 	>=dev-qt/qtmultimedia-5.6.0[widgets]
 	dev-qt/qtserialport
-	>=media-libs/codec2-0.9.1
+	=media-libs/codec2-1.0.3
 	media-libs/opus
 	net-wireless/dsdcc
 	sci-libs/fftw:3.0

--- a/net-wireless/sdrangel/sdrangel-9999.ebuild
+++ b/net-wireless/sdrangel/sdrangel-9999.ebuild
@@ -33,7 +33,8 @@ RDEPEND="
 	>=dev-qt/qtwebsockets-5.6.0
 	>=dev-qt/qtmultimedia-5.6.0[widgets]
 	dev-qt/qtserialport
-	>=media-libs/codec2-0.9.1
+	>=media-libs/codec2-1.0.3
+	!!=media-libs/codec2-1.0.4
 	media-libs/opus
 	net-wireless/dsdcc
 	sci-libs/fftw:3.0


### PR DESCRIPTION
codec2 dependency was upgraded to 1.0.3 (https://github.com/f4exb/sdrangel/commit/93e51e140be0e6fe7588923457985ee4d793071f) but it fails to compile with 1.0.4