### PR TITLE
Update sdrangel-7.18.1.ebuild

### DIFF
--- a/net-wireless/sdrangel/sdrangel-7.18.1.ebuild
+++ b/net-wireless/sdrangel/sdrangel-7.18.1.ebuild
@@ -51,6 +51,7 @@ RDEPEND="
 			>=dev-qt/qtspeech-5.15.0:5
 			>=dev-qt/qtwebengine-5.15.0:5[widgets]
 			>=dev-qt/qtopengl-5.15.0:5
+			>=dev-qt/qtquickcontrols2-5.15.0:5
 		)
 	)
 	qt6? (


### PR DESCRIPTION
The ADS-B demodulator in SDRangel has a map. In order for that map to show, you need to install `dev-qt/qtquickcontrols2` (https://packages.gentoo.org/packages/dev-qt/qtquickcontrols2) otherwise the map will not show and will just be a white screen.  It can be installed manually `emerge --ask dev-qt/qtquickcontrols2` Installing `dev-qt/qtquickcontrols2` also installs `dev-qt/qtgraphicaleffects` which I am fairly confident is needed as well for the map to show. 
Now, I have no experience with Gentoo ebuilds. I've made a pull request because I don't want to always bring up issues in projects, I want to help :') 

Please check because I most likely did it wrong 🙏
-does it go in the `gui` section of the ebuild?
-does `dev-qt/qtgraphicaleffects` get installed automatically same as when installing with emerge or does it need to be added in the ebuild?
-I only tested with qt5, for me at least, SDRangel does not build with -qt5 qt6 USE flag, I get a build error 
-I only tested with SDRangel 7.18.1
-dev-qt/qtquickcontrols2 does not need the [widgets] USE flag