### PR TITLE
dev-libs/nanopb: allow python single target 3.12 and 3.13

### DIFF
--- a/dev-libs/nanopb/metadata.xml
+++ b/dev-libs/nanopb/metadata.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+    <upstream>
+        <remote-id type="github">nanopb/nanopb</remote-id>
+    </upstream>
+</pkgmetadata>

--- a/dev-libs/nanopb/nanopb-0.4.7-r2.ebuild
+++ b/dev-libs/nanopb/nanopb-0.4.7-r2.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{10,11} )
+PYTHON_COMPAT=( python3_{10,11,12,13} )
 
 inherit cmake flag-o-matic python-single-r1
 

--- a/dev-libs/nanopb/nanopb-9999.ebuild
+++ b/dev-libs/nanopb/nanopb-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{10,11} )
+PYTHON_COMPAT=( python3_{10,11,12,13} )
 
 inherit cmake flag-o-matic python-single-r1
 


### PR DESCRIPTION
Since 2024-06-01 the default Python target of Gentoo systems is 3.12.

Current ebuild fails to emerge and requires to set 3.10 or 3.11, but it requires some other python dependencies in system also been rebuild with both default target and 3.10 or 3.11
