### PR TITLE
net-wireless/sdrangel-7.22.7 - Add missing GUI dependencies

### DIFF
--- a/net-wireless/sdrangel/sdrangel-7.22.7.ebuild
+++ b/net-wireless/sdrangel/sdrangel-7.22.7.ebuild
@@ -69,6 +69,8 @@ RDEPEND="
 			dev-qt/qtbase:6[opengl]
 			dev-qt/qtlocation:6
 			dev-qt/qtsvg:6
+			dev-qt/qtspeech:6
+			dev-qt/qtscxml:6
 			dev-qt/qtwebengine:6[widgets]
 		)
 	)


### PR DESCRIPTION
Added 2 missing dependencies required to build the GUI frontend with QT6, cli builds fine without them.